### PR TITLE
feat: Add Graph API key and Futures subgraph ID variables

### DIFF
--- a/.bedrock/.terragrunt/00_variables.tf
+++ b/.bedrock/.terragrunt/00_variables.tf
@@ -330,3 +330,17 @@ variable "validator_eth_node_address" {
   sensitive   = true
   default     = ""
 }
+
+variable "graph_api_key" {
+  description = "The Graph API Key for accessing published subgraphs"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "futures_subgraph_id" {
+  description = "The Graph Subgraph ID for Futures (from published subgraph)"
+  type        = string
+  sensitive   = true
+  default     = ""
+}

--- a/.bedrock/.terragrunt/01_secrets_manager.tf
+++ b/.bedrock/.terragrunt/01_secrets_manager.tf
@@ -27,8 +27,9 @@ resource "aws_secretsmanager_secret_version" "proxy_router" {
   count     = var.proxy_router["create"] ? 1 : 0
   secret_id = aws_secretsmanager_secret.proxy_router[0].id
   secret_string = jsonencode({
-    wallet_private_key = var.proxy_wallet_private_key
-    eth_node_address   = var.proxy_eth_node_address
+    wallet_private_key   = var.proxy_wallet_private_key
+    eth_node_address     = var.proxy_eth_node_address
+    futures_subgraph_url = "https://gateway.thegraph.com/api/${var.graph_api_key}/subgraphs/id/${var.futures_subgraph_id}"
   })
 }
 
@@ -55,8 +56,9 @@ resource "aws_secretsmanager_secret_version" "proxy_validator" {
   count     = var.proxy_validator["create"] ? 1 : 0
   secret_id = aws_secretsmanager_secret.proxy_validator[0].id
   secret_string = jsonencode({
-    wallet_private_key = var.validator_wallet_private_key
-    eth_node_address   = var.validator_eth_node_address
+    wallet_private_key   = var.validator_wallet_private_key
+    eth_node_address     = var.validator_eth_node_address
+    futures_subgraph_url = "https://gateway.thegraph.com/api/${var.graph_api_key}/subgraphs/id/${var.futures_subgraph_id}"
   })
 }
 

--- a/.bedrock/.terragrunt/02_proxy_n_router_svc.tf
+++ b/.bedrock/.terragrunt/02_proxy_n_router_svc.tf
@@ -87,7 +87,6 @@ resource "aws_ecs_task_definition" "proxy_router_use1_1" {
       launch_type = "FARGATE"
       essential   = true
       environment = [
-        { "name" : "FUTURES_SUBGRAPH_URL", "value" : var.account_lifecycle == "prd" ? "https://graph.lmn.lumerin.io/subgraphs/name/futures" : "https://graph.${var.account_lifecycle}.lumerin.io/subgraphs/name/futures" },
         { "name" : "MULTICALL_ADDRESS", "value" : "0xcA11bde05977b3631167028862bE2a173976CA11" },
         { "name" : "FUTURES_ADDRESS", "value" : var.futures_address },
         # { "name" : "FUTURES_VALIDATOR_URL_OVERRIDE", "value" : var.futures_validator_url_override },
@@ -131,7 +130,8 @@ resource "aws_ecs_task_definition" "proxy_router_use1_1" {
       ]
       secrets = [
         { "name" : "WALLET_PRIVATE_KEY", "valueFrom" : "${aws_secretsmanager_secret.proxy_router[0].arn}:wallet_private_key::" },
-        { "name" : "ETH_NODE_ADDRESS", "valueFrom" : "${aws_secretsmanager_secret.proxy_router[0].arn}:eth_node_address::" }
+        { "name" : "ETH_NODE_ADDRESS", "valueFrom" : "${aws_secretsmanager_secret.proxy_router[0].arn}:eth_node_address::" },
+        { "name" : "FUTURES_SUBGRAPH_URL", "valueFrom" : "${aws_secretsmanager_secret.proxy_router[0].arn}:futures_subgraph_url::" }
       ]
       portMappings = [
         {

--- a/.bedrock/.terragrunt/02_proxy_n_validator_svc.tf
+++ b/.bedrock/.terragrunt/02_proxy_n_validator_svc.tf
@@ -86,7 +86,6 @@ resource "aws_ecs_task_definition" "proxy_validator_use1_1" {
       launch_type = "FARGATE"
       essential   = true
       environment = [
-        { "name" : "FUTURES_SUBGRAPH_URL", "value" : var.account_lifecycle == "prd" ? "https://graph.lmn.lumerin.io/subgraphs/name/futures" : "https://graph.${var.account_lifecycle}.lumerin.io/subgraphs/name/futures" },
         { "name" : "MULTICALL_ADDRESS", "value" : "0xcA11bde05977b3631167028862bE2a173976CA11" },
         { "name" : "FUTURES_ADDRESS", "value" : var.futures_address },
         # { "name" : "FUTURES_VALIDATOR_URL_OVERRIDE", "value" : var.futures_validator_url_override },
@@ -131,7 +130,8 @@ resource "aws_ecs_task_definition" "proxy_validator_use1_1" {
       ]
       secrets = [
         { "name" : "WALLET_PRIVATE_KEY", "valueFrom" : "${aws_secretsmanager_secret.proxy_validator[0].arn}:wallet_private_key::" },
-        { "name" : "ETH_NODE_ADDRESS", "valueFrom" : "${aws_secretsmanager_secret.proxy_validator[0].arn}:eth_node_address::" }
+        { "name" : "ETH_NODE_ADDRESS", "valueFrom" : "${aws_secretsmanager_secret.proxy_validator[0].arn}:eth_node_address::" },
+        { "name" : "FUTURES_SUBGRAPH_URL", "valueFrom" : "${aws_secretsmanager_secret.proxy_validator[0].arn}:futures_subgraph_url::" }
       ]
       portMappings = [
         {

--- a/.github/workflows/build-deploy-proxy-router.yml
+++ b/.github/workflows/build-deploy-proxy-router.yml
@@ -101,8 +101,10 @@ jobs:
           run: |
             BUILDTAG=${{ needs.Generate-Tag.outputs.tag_name }}
             BUILDIMAGE=${{ needs.Generate-Tag.outputs.image_name }}
+            # Construct Graph URL from org secrets/vars (using DEV for CI testing)
+            FUTURES_SUBGRAPH_URL="https://gateway.thegraph.com/api/${{ secrets.DEV_GRAPH_APIKEY }}/subgraphs/id/${{ vars.DEV_FUTURES_SUBGRAPH_ID }}"
             docker run -d --name proxy-router-test \
-              -e FUTURES_SUBGRAPH_URL=${{ vars.FUTURES_SUBGRAPH_URL }} \
+              -e FUTURES_SUBGRAPH_URL="${FUTURES_SUBGRAPH_URL}" \
               -e MULTICALL_ADDRESS=${{ vars.MULTICALL_ADDRESS }} \
               -e FUTURES_ADDRESS=${{ vars.FUTURES_ADDRESS }} \
               -e FUTURES_VALIDATOR_URL_OVERRIDE=${{ vars.FUTURES_VALIDATOR_URL_OVERRIDE }} \


### PR DESCRIPTION
- Introduced new variables for Graph API key and Futures subgraph ID in 00_variables.tf.
- Updated secrets manager configurations to include Futures subgraph URL in 01_secrets_manager.tf.
- Modified ECS task definitions to reference the new Futures subgraph URL in 02_proxy_n_router_svc.tf and 02_proxy_n_validator_svc.tf.
- Adjusted GitHub Actions workflow to construct Futures subgraph URL dynamically in build-deploy-proxy-router.yml.