### PR TITLE
Proxy-Router Conversion to TheGraph Complete

### DIFF
--- a/.bedrock/.terragrunt/02_proxy_n_router_svc.tf
+++ b/.bedrock/.terragrunt/02_proxy_n_router_svc.tf
@@ -18,10 +18,7 @@ output "CI_AWS_ECR_CLUSTER_REGION" { value = var.proxy_router["create"] ? var.re
 
 # Define Service (watch for conflict with Gitlab CI/CD)
 resource "aws_ecs_service" "proxy_router_use1_1" {
-  # lifecycle {
-  #   ignore_changes        = [desired_count, task_definition] # May want to change this to kick update to prod when new task is replicated 
-  #   create_before_destroy = true
-  # }
+  lifecycle {ignore_changes        = [desired_count, task_definition]}
   count                  = var.proxy_router["create"] ? 1 : 0
   provider               = aws.use1
   name                   = "svc-${var.proxy_router["svc_name"]}-${substr(var.account_shortname, 8, 3)}-${var.region_shortname}"
@@ -68,7 +65,7 @@ resource "aws_ecs_service" "proxy_router_use1_1" {
 
 # Define Task  
 resource "aws_ecs_task_definition" "proxy_router_use1_1" {
-  # lifecycle {ignore_changes = [container_definitions]}
+  lifecycle {ignore_changes = [container_definitions]}
   count                    = var.proxy_router["create"] ? 1 : 0
   provider                 = aws.use1
   family                   = "tsk-${var.proxy_router["svc_name"]}"

--- a/.bedrock/.terragrunt/02_proxy_n_validator_svc.tf
+++ b/.bedrock/.terragrunt/02_proxy_n_validator_svc.tf
@@ -18,7 +18,7 @@ output "proxy_validator_api_target" { value = var.proxy_validator["create"] ? "u
 
 # Define Service (watch for conflict with Gitlab CI/CD)
 resource "aws_ecs_service" "proxy_validator_use1_1" {
-  # lifecycle {ignore_changes        = [desired_count, task_definition] }
+  lifecycle {ignore_changes        = [desired_count, task_definition] }
   count                  = var.proxy_validator["create"] ? 1 : 0
   provider               = aws.use1
   name                   = "svc-${var.proxy_validator["svc_name"]}-${substr(var.account_shortname, 8, 3)}-${var.region_shortname}"
@@ -65,9 +65,7 @@ resource "aws_ecs_service" "proxy_validator_use1_1" {
 
 # Define Task  
 resource "aws_ecs_task_definition" "proxy_validator_use1_1" {
-
-  # lifecycle {ignore_changes = [container_definitions]}
-  
+  lifecycle {ignore_changes = [container_definitions]}
   count                    = var.proxy_validator["create"] ? 1 : 0
   provider                 = aws.use1
   family                   = "tsk-${var.proxy_validator["svc_name"]}"


### PR DESCRIPTION
fix: Update lifecycle blocks in ECS service and task definitions
- Removed commented-out lifecycle blocks and enabled them for desired_count and task_definition in both 02_proxy_n_router_svc.tf and 02_proxy_n_validator_svc.tf.
- Ensured consistency in lifecycle management for ECS resources.