### PR TITLE
fix: Update subgraph client URLs in tests

### DIFF
--- a/internal/repositories/subgraph/client_test.go
+++ b/internal/repositories/subgraph/client_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestGetAllPositions(t *testing.T) {
-	client := NewClient("https://graphidx.dev.lumerin.io/subgraphs/name/marketplace")
+	client := NewClient("https://api.studio.thegraph.com/query/1724245/lumerin-dev-futures/version/latest")
 	deliveryAt := time.Unix(1763679600, 0)
 	positions, err := client.GetAllPositions(context.Background(), deliveryAt)
 	fmt.Printf("%+v\n", positions)
@@ -20,7 +20,7 @@ func TestGetAllPositions(t *testing.T) {
 }
 
 func TestGetPositionsBySeller(t *testing.T) {
-	client := NewClient("https://graphidx.dev.lumerin.io/subgraphs/name/marketplace")
+	client := NewClient("https://api.studio.thegraph.com/query/1724245/lumerin-dev-futures/version/latest")
 	participantAddress := common.HexToAddress("0xb4b12a69fdbb70b31214d4d3c063752c186ff8de")
 	deliveryAt := time.Unix(1763679600, 0)
 	positions, err := client.GetPositionsBySeller(context.Background(), participantAddress, deliveryAt)


### PR DESCRIPTION
- Changed the subgraph client URLs in `client_test.go` to point to the new Graph API endpoint for the Lumerin Futures subgraph.
- Ensured that both `TestGetAllPositions` and `TestGetPositionsBySeller` use the updated URL for consistency in testing.