### PR TITLE
fix: add nil check before writing to dest in handshake handler

### DIFF
--- a/internal/resources/hashrate/proxy/handler_first_connect.go
+++ b/internal/resources/hashrate/proxy/handler_first_connect.go
@@ -72,15 +72,22 @@ func (p *HandlerFirstConnect) handleSource(ctx context.Context, msg i.MiningMess
 	case *m.MiningExtranonceSubscribe:
 		// Pass through extranonce subscription to pool
 		p.proxy.logDebugf("forwarding mining.extranonce.subscribe from source")
-		return nil, p.proxy.dest.Write(ctx, msgTyped)
+		if p.proxy.dest != nil {
+			return nil, p.proxy.dest.Write(ctx, msgTyped)
+		}
+		return nil, nil
 
 	case *m.MiningSubmit:
 		return nil, fmt.Errorf("unexpected handshake message from source: %s", string(msg.Serialize()))
 
 	default:
 		p.proxy.logWarnf("unknown handshake message from source: %s", string(msg.Serialize()))
-		// todo: maybe just return message, so pipe will write it
-		return nil, p.proxy.dest.Write(ctx, msgTyped)
+		// Only forward if destination is initialized
+		if p.proxy.dest != nil {
+			return nil, p.proxy.dest.Write(ctx, msgTyped)
+		}
+		// Drop message if destination not ready
+		return nil, nil
 	}
 }
 


### PR DESCRIPTION
## Summary
Fixes secondary crash discovered after PR #83 deployment. Adds defensive nil checks before attempting to write to destination during handshake phase.

## Root Cause
After deploying PR #83 (which fixed the logging crash), a second nil pointer issue was discovered at 2026-02-10 20:56 UTC:

When miners send unexpected protocol messages before the destination connection is initialized (e.g., `eth_submitLogin` from Ethereum miners connecting to Bitcoin proxy), the code attempts to forward the message via `p.proxy.dest.Write()`. However, `p.proxy.dest` is nil during early handshake, causing panic at `conn_dest.go:139` via `handler_first_connect.go:83`.

## Changes Made
Added defensive nil checks in `handler_first_connect.go` before writing to dest:

1. **MiningExtranonceSubscribe case:**
   - Check if `p.proxy.dest != nil` before forwarding
   - Return nil, nil if dest not ready (safe drop)

2. **Default case (unknown messages):**
   - Check if `p.proxy.dest != nil` before forwarding  
   - Return nil, nil if dest not ready (safe drop)
   - Updated comment to clarify behavior

## Impact
- ✅ Resolves secondary crash pattern at conn_dest.go:139
- ✅ Handles protocol mismatches gracefully (e.g., Ethereum miners on Bitcoin proxy)
- ✅ Complements PR #83 to fully stabilize handshake phase
- ✅ No performance impact (just pointer checks)

## Evidence
**Crash pattern:**
```
panic: runtime error: invalid memory address or nil pointer dereference  
[signal SIGSEGV: segmentation violation code=0x1 addr=0x110 pc=0x8feae6]
at conn_dest.go:139 via handler_first_connect.go:83
```

**Trigger log (showing PR #83 logging fix working):**
```json
{"level":"warn","logger":"PRX","msg":"unknown handshake message from source: {\"id\":2,\"method\":\"eth_submitLogin\"...}",
"SrcAddr":"188.166.37.58:47284","DstAddr":"not-initialized","DstPort":"not-connected"}
```

The logging successfully showed "not-initialized" and "not-connected" (PR #83 fix working), but then crashed trying to forward the message.

## Dependencies
- Requires PR #83 to be merged first (already done)
- This is a follow-up fix discovered during production monitoring


Made with [Cursor](https://cursor.com)